### PR TITLE
Error Handling - Disabled JS & WebGL

### DIFF
--- a/src/components/LogoLayout/index.tsx
+++ b/src/components/LogoLayout/index.tsx
@@ -1,0 +1,5 @@
+import TomatLogo, { TomatLogoProps } from "../TomatLogo";
+
+export default function LogoLayout(props: TomatLogoProps) {
+    return <TomatLogo {...props} />;
+}

--- a/src/components/SilentErrorBoundary/index.ts
+++ b/src/components/SilentErrorBoundary/index.ts
@@ -16,7 +16,6 @@ export default class SilentErrorBoundary extends React.Component<SilentErrorBoun
     }
 
     componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-        // eslint-disable-next-line no-console
         console.error("SilentErrorBoundary caught an error", error, errorInfo);
     }
 

--- a/src/components/SilentErrorBoundary/index.ts
+++ b/src/components/SilentErrorBoundary/index.ts
@@ -1,0 +1,30 @@
+import React, { ErrorInfo } from "react";
+
+export type SilentErrorBoundaryProps = React.PropsWithChildren<{
+    fallback: JSX.Element;
+}>;
+export type SilentErrorBoundaryState = { hasError: boolean };
+
+export default class SilentErrorBoundary extends React.Component<SilentErrorBoundaryProps, SilentErrorBoundaryState> {
+    constructor(props: SilentErrorBoundaryProps) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(_: Error) {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+        // eslint-disable-next-line no-console
+        console.error("SilentErrorBoundary caught an error", error, errorInfo);
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return this.props.fallback;
+        }
+
+        return this.props.children;
+    }
+}

--- a/src/components/TomatLogo/index.tsx
+++ b/src/components/TomatLogo/index.tsx
@@ -5,6 +5,7 @@ import { CSSProperties, Dispatch, RefObject, SetStateAction, useEffect, useRef, 
 import { clamp } from "lib/math";
 import { transform, waitAndTransform } from "lib/transforms/transform";
 import OpaqueFilter from "lib/filters/opaqueFilter";
+import SilentErrorBoundary from "../SilentErrorBoundary";
 
 export type TomatLogoProps = {
     width: number;
@@ -62,21 +63,23 @@ export default function TomatLogo({
         <>
             <noscript>{children}</noscript>
             {displayChildren ? children : <></>}
-            <Stage
-                width={stageSize[0]}
-                height={stageSize[1]}
-                options={{ backgroundAlpha: 0 }}
-                style={clickable ? style : {}}
-            >
-                <Logo
-                    width={width}
-                    height={height}
-                    interactable={interactable}
-                    clickable={clickable}
-                    stageSize={stageSize}
-                    setDisplayChildren={setDisplayChildren}
-                />
-            </Stage>
+            <SilentErrorBoundary fallback={children}>
+                <Stage
+                    width={stageSize[0]}
+                    height={stageSize[1]}
+                    options={{ backgroundAlpha: 0 }}
+                    style={clickable ? style : {}}
+                >
+                    <Logo
+                        width={width}
+                        height={height}
+                        interactable={interactable}
+                        clickable={clickable}
+                        stageSize={stageSize}
+                        setDisplayChildren={setDisplayChildren}
+                    />
+                </Stage>
+            </SilentErrorBoundary>
         </>
     );
 }

--- a/src/components/TomatLogo/index.tsx
+++ b/src/components/TomatLogo/index.tsx
@@ -60,6 +60,7 @@ export default function TomatLogo({
 
     return (
         <>
+            <noscript>{children}</noscript>
             {displayChildren ? children : <></>}
             <Stage
                 width={stageSize[0]}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import { Inter } from "@next/font/google";
 import BasicLayout from "@/components/BasicLayout";
-import TomatLogo from "@/components/TomatLogo";
+import LogoLayout from "@/components/LogoLayout";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -10,15 +10,15 @@ const description = "Hello, world!";
 export default function Home() {
     return (
         <BasicLayout title={title} description={description}>
-            <main className="w-full h-full">
-                <div className="w-full h-full flex justify-center items-center">
-                    <TomatLogo width={250} height={250} interactable clickable>
+            <LogoLayout width={250} height={250} interactable clickable>
+                <main className="w-full h-full">
+                    <div className="w-full h-full flex justify-center items-center">
                         <h1>
                             <em>Generally, I&apos;m a modest guy.</em>
                         </h1>
-                    </TomatLogo>
-                </div>
-            </main>
+                    </div>
+                </main>
+            </LogoLayout>
         </BasicLayout>
     );
 }

--- a/src/pages/test.tsx
+++ b/src/pages/test.tsx
@@ -1,6 +1,7 @@
 import { Inter } from "@next/font/google";
 import BasicLayout from "@/components/BasicLayout";
 import TomatLogo from "@/components/TomatLogo";
+import LogoLayout from "@/components/LogoLayout";
 
 const title = "/test";
 const description = "rr";
@@ -8,9 +9,9 @@ const description = "rr";
 export default function Test() {
     return (
         <BasicLayout title={title} description={description}>
-            <main className="w-full h-full">
-                <div className="w-full h-full flex justify-center items-center">
-                    <TomatLogo width={250} height={250} interactable clickable>
+            <LogoLayout width={250} height={250} interactable clickable>
+                <main className="w-full h-full">
+                    <div className="w-full h-full flex justify-center items-center">
                         <iframe
                             width="560"
                             height="315"
@@ -20,9 +21,9 @@ export default function Test() {
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                             allowFullScreen
                         ></iframe>
-                    </TomatLogo>
-                </div>
-            </main>
+                    </div>
+                </main>
+            </LogoLayout>
         </BasicLayout>
     );
 }


### PR DESCRIPTION
*Resolves #4 and resolves #5.*

# Goal

This PR introduces basic handling in cases where the user has JavaScript disabled or WebGL disabled.

## Changes

If **JavaScript is disabled**...

- *children are displayed immediately*, skipping trying to display the logo.

If **WebGL is disabled**...

- any errors thrown by `Stage` *are caught and silently handled, falling back to rendering the children*.

## Notes

This PR also introduces the `LogoLayout` component to allow for easily wrapping around `TomatLogo`, as well as abstracting aspects of it, in the future.