### PR TITLE
Fix undertale flag numbers off by one

### DIFF
--- a/public/undertale/flags.html
+++ b/public/undertale/flags.html
@@ -207,54 +207,60 @@
     </tr>
     <tr>
         <td>29</td>
+        <td>unused</td>
+        <td></td>
+        <td></td>
+    </tr>
+    <tr>
+        <td>30</td>
         <td>tutorial_froggit_encountered</td>
         <td>bool</td>
         <td></td>
     </tr>
     <tr>
-        <td>30</td>
+        <td>31</td>
         <td>pushed_rock_1</td>
         <td>bool</td>
         <td></td>
     </tr>
     <tr>
-        <td>31</td>
+        <td>32</td>
         <td>pushed_rock_2</td>
         <td>bool</td>
         <td></td>
     </tr>
     <tr>
-        <td>32</td>
+        <td>33</td>
         <td>pushed_rock_3</td>
         <td>bool</td>
         <td></td>
     </tr>
     <tr>
-        <td>33</td>
+        <td>34</td>
         <td>candy_taken</td>
         <td>range</td>
         <td></td>
     </tr>
     <tr>
-        <td>34</td>
+        <td>35</td>
         <td>pushed_rock_4</td>
         <td>bool</td>
         <td></td>
     </tr>
     <tr>
-        <td>35</td>
+        <td>36</td>
         <td>spared_napstablook</td>
         <td>bool</td>
         <td></td>
     </tr>
     <tr>
-        <td>36</td>
+        <td>37</td>
         <td>waited_toriel</td>
         <td>bool</td>
         <td>Wait for Toriel to call you when she asks to stay in a room.</td>
     </tr>
     <tr>
-        <td>37..39</td>
+        <td>38..39</td>
         <td>unused</td>
         <td></td>
         <td></td>


### PR DESCRIPTION
`candy_taken` is `global.flag[34]`, not `[33]`. (for Undertale v1.08)